### PR TITLE
Adrian swailing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ That outputs to the supplied logger:
 
 ```
 this is the primary message: 12345
-this is an optional detail: syscall failed
-also an optional hint to do yadda yadda
+DETAIL: this is an optional detail: syscall failed
+HINT: also an optional hint to do yadda yadda
 ```
 
 But you can always fallback to regular style logging:
@@ -73,6 +73,34 @@ Outputs:
 
 ```
 this is the primary message: 12345
+```
+
+
+You can also disable the "DETAIL: ..." and "HINT: ..." prefix, e.g.
+
+```python
+logger = swailing.Logger(logging.getLogger(), with_prefix=False)
+```
+
+
+It might make sense to pass in a dictionary of information to `.detail` and have
+the logger json dump the dict. In that case you can do:
+
+```python
+logger = swailing.Logger(logging.getLogger(), structured_detail=True)
+
+with logger.info() as L:
+	L.primary('this is the primary message %d', 12345)
+	L.detail({'request_id': 12345, 'request_ts': 1454026366})
+	L.hint('some hinty stuff')
+```
+
+Outputs:
+
+```
+this is the primary message: 12345
+DETAIL: {"request_ts": 1454026366, "request_id": 12345}
+HINT: some hinty stuff
 ```
 
 Throttling:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="swailing",
-    version="0.1.1",
+    version="0.1.2",
     packages=['swailing'],
     author="Wes Chow",
     author_email="wes@chartbeat.com",

--- a/swailing/logger.py
+++ b/swailing/logger.py
@@ -1,5 +1,6 @@
 
 import logging
+import json
 import threading
 from contextlib import contextmanager
 
@@ -16,7 +17,13 @@ class Logger(object):
 
     """
 
-    def __init__(self, name_or_logger, fill_rate=None, capacity=None, verbosity=HINT):
+    def __init__(self,
+                 name_or_logger,
+                 fill_rate=None,
+                 capacity=None,
+                 verbosity=HINT,
+                 structured_detail=True,
+                 with_prefix=True):
         """Set up Logger-like object with some swailing goodness.
 
         name_or_logger is either a (possibly unicode) string or a
@@ -34,6 +41,13 @@ class Logger(object):
         Setting it to DETAIL will stop hint outputs. Setting it to
         HINT allows all output.
 
+        When structured_detail is True, FancyLogContext.detail(msg) expects
+        msg to be a dict and json dumps it when logging.
+
+        When with_prefix is True, FancyLogContext.detail and
+        FancyLogContext.hint will prefix their output with "DETAIL: " and
+        "HINT: ", respectively.
+
         """
 
         if fill_rate and capacity:
@@ -48,6 +62,8 @@ class Logger(object):
             self._logger = name_or_logger
 
         self._verbosity = verbosity
+        self._structured_detail = structured_detail
+        self._with_prefix = with_prefix
 
     def debug(self, msg=None, *args, **kwargs):
         """Write log at DEBUG level. Same arguments as Python's built-in
@@ -118,7 +134,11 @@ class Logger(object):
             if msg is not None:
                 self._logger.log(level, msg, *args, **kwargs)
 
-            return FancyLogContext(self._logger, level, self._verbosity)
+            return FancyLogContext(self._logger,
+                                   level,
+                                   self._verbosity,
+                                   self._structured_detail,
+                                   self._with_prefix)
         else:
             return NoopLogContext()
 
@@ -129,11 +149,18 @@ class FancyLogContext(object):
 
     """
 
-    def __init__(self, logger, level, verbosity):
+    def __init__(self,
+                 logger,
+                 level,
+                 verbosity,
+                 structured_detail,
+                 with_prefix):
         self._logger = logger
         self._level = level
         self._verbosity = verbosity
         self._log = {}
+        self._structured_detail = structured_detail
+        self._with_prefix = with_prefix
 
     def __enter__(self):
         return self
@@ -152,12 +179,19 @@ class FancyLogContext(object):
             self._log[PRIMARY] = (msg, args, kwargs)
 
     def detail(self, msg, *args, **kwargs):
+        spec = 'DETAIL: %s' if self._with_prefix else '%s'
         if self._verbosity >= DETAIL:
+            if self._structured_detail:
+                msg = spec % json.dumps(msg)
+            else:
+                msg = spec % msg
+
             self._log[DETAIL] = (msg, args, kwargs)
 
     def hint(self, msg, *args, **kwargs):
+        spec = 'HINT: %s' if self._with_prefix else '%s'
         if self._verbosity >= HINT:
-            self._log[HINT] = (msg, args, kwargs)
+            self._log[HINT] = (spec % msg, args, kwargs)
 
 
 class NoopLogContext(object):

--- a/swailing/logger.py
+++ b/swailing/logger.py
@@ -72,6 +72,14 @@ class Logger(object):
 
         return self._log(logging.ERROR, msg, args, kwargs)
 
+    def exception(self, msg=None, *args, **kwargs):
+        """Similar to DEBUG but at ERROR level with exc_info set.
+
+        https://github.com/python/cpython/blob/2.7/Lib/logging/__init__.py#L1472
+        """
+        kwargs['exc_info'] = 1
+        return self._log(logging.ERROR, msg, args, kwargs)
+
     def critical(self, msg=None, *args, **kwargs):
         """Similar to DEBUG but at CRITICAL level."""
 

--- a/swailing/logger.py
+++ b/swailing/logger.py
@@ -22,7 +22,7 @@ class Logger(object):
                  fill_rate=None,
                  capacity=None,
                  verbosity=HINT,
-                 structured_detail=True,
+                 structured_detail=False,
                  with_prefix=True):
         """Set up Logger-like object with some swailing goodness.
 
@@ -41,13 +41,12 @@ class Logger(object):
         Setting it to DETAIL will stop hint outputs. Setting it to
         HINT allows all output.
 
-        When structured_detail is True, FancyLogContext.detail(msg) expects
-        msg to be a dict and json dumps it when logging.
+        When structured_detail is True, logger.detail(msg) expects msg to be a
+        dict and json dumps it when logging.
 
-        When with_prefix is True, FancyLogContext.detail and
-        FancyLogContext.hint will prefix their output with "DETAIL: " and
+        When with_prefix is True, logger.detail and logger.hint will prefix
+        their output with "DETAIL: " and
         "HINT: ", respectively.
-
         """
 
         if fill_rate and capacity:


### PR DESCRIPTION
@wesc 

Adds exception method to Logger, structured detail (json dumping msg passed to `FancyLogContext.detail`), and prefixed output for hint and detail e.g. "DETAIL: ...".

By default, I chose structured detail and prefixed output to be enabled when initializing the Logger. I didn't want to sully the current unittests and make them harder to read so I set `with_prefix` and `structured_detail` to False. That way we can focus on the context manager and throttling logic. There are two new independent tests for `with_prefix` and `structured_logging`.

Unfortunately this means all of the current tests have the aforementioned flags passed as kwargs to swailing.Logger. Kind of verbose, but I thought this was the right way.
